### PR TITLE
Fix/r.js

### DIFF
--- a/lib/capistrano/magento2/defaults.rb
+++ b/lib/capistrano/magento2/defaults.rb
@@ -66,6 +66,7 @@ set :magento_deploy_clear_opcache, fetch(:magento_deploy_clear_opcache, true)
 set :magento_deploy_clear_opcache_additional_websites, fetch(:magento_deploy_clear_opcache_additional_websites, [])
 set :magento_deploy_clear_varnish, fetch(:magento_deploy_clear_varnish, true)
 set :composer_install_flags, fetch(:composer_install_flags, '--prefer-dist --no-interaction --no-progress --no-suggest');
+set :rjs_executable_path, fetch(:rjs_executable_path, 'r.js')
 
 # deploy targetting defaults
 set :magento_deploy_setup_role, fetch(:magento_deploy_setup_role, :all)

--- a/lib/capistrano/tasks/magento.rake
+++ b/lib/capistrano/tasks/magento.rake
@@ -115,7 +115,7 @@ namespace :magento do
               if theme != 'Magento/backend'
                 deploy_languages.each do |language|
                   execute "mv", "#{release_path}/pub/static/frontend/#{theme}/#{language}/ #{release_path}/pub/static/frontend/#{theme}/#{language}_source/"
-                  execute "which", "r.js"
+                  execute "/data/web/.nvm/versions/node/v12.13.0/bin/r.js"
                   execute "r.js", "-o #{release_path}/build.js dir=pub/static/frontend/#{theme}/#{language}/ baseUrl=#{release_path}/pub/static/frontend/#{theme}/#{language}_source/"
                 end
               end

--- a/lib/capistrano/tasks/magento.rake
+++ b/lib/capistrano/tasks/magento.rake
@@ -108,14 +108,19 @@ namespace :magento do
       on release_roles :all do
         deploy_themes = fetch(:magento_deploy_themes)
         deploy_languages = fetch(:magento_deploy_languages)
+        rjs_executable_path = fetch(:rjs_executable_path)
 
         within release_path do
           if test "[[ -f #{release_path}/build.js ]]"
             deploy_themes.each do |theme|
               if theme != 'Magento/backend'
                 deploy_languages.each do |language|
-                  # execute "mv", "#{release_path}/pub/static/frontend/#{theme}/#{language}/ #{release_path}/pub/static/frontend/#{theme}/#{language}_source/"
-                  execute "/data/web/.nvm/versions/node/v12.13.0/bin/r.js", "-o #{release_path}/build.js dir=pub/static/frontend/#{theme}/#{language}/ baseUrl=#{release_path}/pub/static/frontend/#{theme}/#{language}_source/"
+                  if test "[[ -f #{rjs_executable_path} ]]"
+                    execute "mv", "#{release_path}/pub/static/frontend/#{theme}/#{language}/ #{release_path}/pub/static/frontend/#{theme}/#{language}_source/"
+                    execute "#{rjs_executable_path}", "-o #{release_path}/build.js dir=pub/static/frontend/#{theme}/#{language}/ baseUrl=#{release_path}/pub/static/frontend/#{theme}/#{language}_source/"
+                  else
+                    puts "\e[0;31m    Warning: r.js executable not found, you can assign a custom path to rjs_executable_path. Skipping this step!\n\e[0m\n"
+                  end
                 end
               end
             end

--- a/lib/capistrano/tasks/magento.rake
+++ b/lib/capistrano/tasks/magento.rake
@@ -114,9 +114,9 @@ namespace :magento do
             deploy_themes.each do |theme|
               if theme != 'Magento/backend'
                 deploy_languages.each do |language|
-                  execute "mv", "#{release_path}/pub/static/frontend/#{theme}/#{language}/ #{release_path}/pub/static/frontend/#{theme}/#{language}_source/"
+                  # execute "mv", "#{release_path}/pub/static/frontend/#{theme}/#{language}/ #{release_path}/pub/static/frontend/#{theme}/#{language}_source/"
                   execute "/data/web/.nvm/versions/node/v12.13.0/bin/r.js"
-                  execute "r.js", "-o #{release_path}/build.js dir=pub/static/frontend/#{theme}/#{language}/ baseUrl=#{release_path}/pub/static/frontend/#{theme}/#{language}_source/"
+                  # execute "r.js", "-o #{release_path}/build.js dir=pub/static/frontend/#{theme}/#{language}/ baseUrl=#{release_path}/pub/static/frontend/#{theme}/#{language}_source/"
                 end
               end
             end

--- a/lib/capistrano/tasks/magento.rake
+++ b/lib/capistrano/tasks/magento.rake
@@ -115,8 +115,7 @@ namespace :magento do
               if theme != 'Magento/backend'
                 deploy_languages.each do |language|
                   # execute "mv", "#{release_path}/pub/static/frontend/#{theme}/#{language}/ #{release_path}/pub/static/frontend/#{theme}/#{language}_source/"
-                  execute "/data/web/.nvm/versions/node/v12.13.0/bin/r.js"
-                  # execute "r.js", "-o #{release_path}/build.js dir=pub/static/frontend/#{theme}/#{language}/ baseUrl=#{release_path}/pub/static/frontend/#{theme}/#{language}_source/"
+                  execute "/data/web/.nvm/versions/node/v12.13.0/bin/r.js", "-o #{release_path}/build.js dir=pub/static/frontend/#{theme}/#{language}/ baseUrl=#{release_path}/pub/static/frontend/#{theme}/#{language}_source/"
                 end
               end
             end

--- a/lib/capistrano/tasks/magento.rake
+++ b/lib/capistrano/tasks/magento.rake
@@ -115,6 +115,7 @@ namespace :magento do
               if theme != 'Magento/backend'
                 deploy_languages.each do |language|
                   execute "mv", "#{release_path}/pub/static/frontend/#{theme}/#{language}/ #{release_path}/pub/static/frontend/#{theme}/#{language}_source/"
+                  execute "which", "r.js"
                   execute "r.js", "-o #{release_path}/build.js dir=pub/static/frontend/#{theme}/#{language}/ baseUrl=#{release_path}/pub/static/frontend/#{theme}/#{language}_source/"
                 end
               end


### PR DESCRIPTION
You can now set a custom path to the r.js executable in rjs_executable_path. The path will be checked, and if no file can be found a warning is thrown.
Inspired by the Tuinmeubelland m2 deploy pipeline, which had troubles finding the r.js executable, even though it was positioned in the path of the deploy user.